### PR TITLE
BugFix: DocumentationMD.psm1 - Header below instead of above table

### DIFF
--- a/Extensions/DocumentationMD.psm1
+++ b/Extensions/DocumentationMD.psm1
@@ -376,6 +376,7 @@ function Add-MDTableItems
 {
     param($obj, $objectType, $items, $properties, $lngId, [switch]$AddCategories, [switch]$AddSubcategories, $captionOverride)
 
+
     if($captionOverride)
     {
         $caption = $captionOverride
@@ -388,7 +389,9 @@ function Add-MDTableItems
     {
         $caption = "$((Get-GraphObjectName $obj $objectType)) ($($objectType.Title))"
     }
-
+    
+    Add-MDHeader $caption -Level 6 -TOT -AddParagraph
+    
     $tableText =  [System.Text.StringBuilder]::new()
     $tableText.AppendLine("<table class='table-settings'>")
     $tableText.AppendLine("<tr class='table-header1'>")
@@ -522,8 +525,7 @@ function Add-MDTableItems
 
     $tableText.AppendLine("</table>")
     Add-MDText $tableText.ToString()
-    
-    Add-MDHeader $caption -Level 6 -TOT -AddParagraph
+
 }
 
 function Add-MDText


### PR DESCRIPTION
Fixes a bug where the MD header for a table was placed below the table instead of above the table.